### PR TITLE
Specify torch versions to allow for pip install of this repo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-torch
-torchaudio
-torchvision
+torch==2.1.0
+torchaudio==2.1.0
+torchvision==0.16.0
 torchdiffeq>=0.2.3
 torchsde>=0.2.6
 einops>=0.6.0


### PR DESCRIPTION
Hi there, I found your repo and have been using it to run comfyui nodes as code. It's very helpful!

For some reason though, when I was pip installing your repo on baseten, it would install a nightly build of torch 2.3.0 compiled for CPU. No idea why this was the case... Anyway by specifying the version of torch, vision and audio it fixed the issue. I thought this might solve a headache for other people trying to do the same thing, although it looks like you've been wrestling with these issues for a while so maybe this isn't too helpful. Who knows though.

Also, weird coincidence: I also made a 'community created card game.' It was [collective.gg](https://www.collective.gg/) if you ever heard of it. Nice to meet you :smile: 