### PR TITLE
Allow iteration over folder paths

### DIFF
--- a/comfy/cmd/folder_paths.py
+++ b/comfy/cmd/folder_paths.py
@@ -61,6 +61,9 @@ class FolderNames:
     def __len__(self):
         return len(self.contents)
 
+    def __iter__(self):
+        return iter(self.contents)    
+    
     def items(self):
         return self.contents.items()
 


### PR DESCRIPTION
When installing the [ComfyUI IP Adapter Plus](https://github.com/cubiq/ComfyUI_IPAdapter_plus) custom nodes, comfyui fails to import due to being unable iterate over the folder paths. This PR overrides the iterator.

Error
```
  File "E:\dev\sd\sd-experiment\custom_nodes\ComfyUI_IPAdapter_plus\IPAdapterPlus.py", line 23, in <module>
    if "ipadapter" not in folder_paths.folder_names_and_paths:
  File "E:\dev\sd\sd-experiment\.venv\lib\site-packages\comfy\cmd\folder_paths.py", line 47, in __getitem__
    raise RuntimeError("expected folder path")
RuntimeError: expected folder path

Cannot import E:\dev\sd\sd-experiment\custom_nodes\ComfyUI_IPAdapter_plus module for custom nodes: expected folder path
```

[IPAdapterPlus.py](https://github.com/cubiq/ComfyUI_IPAdapter_plus/blob/main/IPAdapterPlus.py) file where the error occurs:
```python
# set the models directory backward compatible
GLOBAL_MODELS_DIR = os.path.join(folder_paths.models_dir, "ipadapter")
MODELS_DIR = GLOBAL_MODELS_DIR if os.path.isdir(GLOBAL_MODELS_DIR) else os.path.join(os.path.dirname(os.path.realpath(__file__)), "models")
if "ipadapter" not in folder_paths.folder_names_and_paths:
    current_paths = [MODELS_DIR]
else:
    current_paths, _ = folder_paths.folder_names_and_paths["ipadapter"]
```

