### PR TITLE
fix(model_management): provide model_mmap_residency / pinned_memory_size / partially_unload_ram defaults on ModelManageableStub

### DIFF
--- a/comfy/model_management_types.py
+++ b/comfy/model_management_types.py
@@ -184,6 +184,12 @@ class ModelManageable(HooksSupport, TrainingSupport, Protocol):
 
     def model_dtype(self) -> torch.dtype: ...
 
+    def model_mmap_residency(self, free: bool = False) -> tuple[int, int]: ...
+
+    def pinned_memory_size(self) -> int: ...
+
+    def partially_unload_ram(self, ram_to_unload: int): ...
+
     def lowvram_patch_counter(self) -> int: ...
 
     def partially_load(self, device_to: torch.device, extra_memory: int = 0, force_patch_weights: bool = False) -> int:  ...
@@ -288,6 +294,19 @@ class ModelManageableStub(HooksSupportStub, TrainingSupportStub, ModelManageable
 
     def model_dtype(self) -> torch.dtype:
         return next(self.model.parameters()).dtype
+
+    @override
+    def model_mmap_residency(self, free: bool = False) -> tuple[int, int]:
+        from .model_management import module_mmap_residency
+        return module_mmap_residency(self.model, free=free)
+
+    @override
+    def pinned_memory_size(self) -> int:
+        return 0
+
+    @override
+    def partially_unload_ram(self, ram_to_unload: int):
+        pass
 
     def lowvram_patch_counter(self) -> int:
         """

--- a/tests/unit/comfy_test/model_management_types_test.py
+++ b/tests/unit/comfy_test/model_management_types_test.py
@@ -1,0 +1,74 @@
+"""Regression: ModelManageableStub must satisfy every method
+load_models_gpu (model_management.py) invokes on a loaded model. Previously
+absent: model_mmap_residency, pinned_memory_size, partially_unload_ram.
+Any class extending ModelManageableStub directly — e.g.
+LatentUpscaleModelManageable in comfy_extras/nodes/nodes_latent_upscaler.py
+— inherited the gap and raised AttributeError when memory-managed."""
+
+import torch
+
+from comfy.model_management_types import ModelManageable, ModelManageableStub
+
+
+# Every method load_models_gpu invokes on a managed model. If any of these
+# is missing from Protocol or Stub, an LTX-style production failure recurs.
+_HOT_PATH_METHODS = (
+    "current_loaded_device",
+    "detach",
+    "is_clone",
+    "is_dynamic",
+    "loaded_size",
+    "lowvram_patch_counter",
+    "model_dtype",
+    "model_mmap_residency",
+    "model_patches_to",
+    "model_size",
+    "partially_load",
+    "partially_unload",
+    "partially_unload_ram",
+    "pinned_memory_size",
+)
+
+
+class _MinimalManageable(ModelManageableStub):
+    def __init__(self, model: torch.nn.Module):
+        self.model = model
+        self.load_device = torch.device("cpu")
+        self.offload_device = torch.device("cpu")
+
+    def patch_model(self, device_to=None, lowvram_model_memory=0, load_weights=True, force_patch_weights=False):
+        return self.model
+
+    def unpatch_model(self, device_to=None, unpatch_weights=False):
+        return self.model
+
+
+def test_protocol_declares_every_hot_path_method():
+    missing = [m for m in _HOT_PATH_METHODS if not hasattr(ModelManageable, m)]
+    assert missing == [], f"ModelManageable Protocol missing: {missing}"
+
+
+def test_stub_provides_every_hot_path_method():
+    missing = [m for m in _HOT_PATH_METHODS if not hasattr(ModelManageableStub, m)]
+    assert missing == [], f"ModelManageableStub missing: {missing}"
+
+
+def test_stub_replays_load_models_gpu_call_sequence_without_attribute_error():
+    # Mirrors the exact sequence load_models_gpu uses on each loaded model.
+    m = _MinimalManageable(torch.nn.Linear(8, 8))
+    assert m.is_dynamic() is False
+    assert m.loaded_size() >= 0
+    resident, total = m.model_mmap_residency()
+    assert (resident, total) == (0, sum(t.nbytes for t in m.model.state_dict().values()))
+    assert m.pinned_memory_size() == 0
+    m.partially_unload_ram(1024)  # no-op default; must not raise
+    resident, _ = m.model_mmap_residency(free=True)
+    assert resident == 0
+
+
+def test_stub_default_reports_zero_resident_for_non_mmap_module():
+    module = torch.nn.Linear(8, 8)
+    expected_total = sum(t.nbytes for t in module.state_dict().values())
+    resident, total = _MinimalManageable(module).model_mmap_residency()
+    assert resident == 0
+    assert total == expected_total


### PR DESCRIPTION
The symptom looks like a custom-node bug — `AttributeError` on a wrapper around a third-party model — but the gap is in HiddenSwitch's own `ModelManageableStub`.

## Impact

Any workflow that loads a model through `LatentUpscaleModelLoader` (`comfy_extras/nodes/nodes_latent_upscaler.py:89`) fails the moment `load_models_gpu` tries to manage it. That covers both upscale model families this loader supports:

- **Hunyuan video super-resolution** (`HunyuanVideo15SRModel`)
- **Lightricks LTX latent upsampling** (`LatentUpsampler`)

Failure is `AttributeError: 'LatentUpscaleModelManageable' object has no attribute 'model_mmap_residency'` raised from `LoadedModel.model_mmap_residency` (`model_management.py:621`). The crash happens during VRAM allocation, well before any sampling — so any graph wiring an upscale model in is dead on arrival, regardless of the rest of the graph.

## Root cause

`comfy.model_management.load_models_gpu` invokes three methods on every loaded model that aren't declared on the `ModelManageable` Protocol or implemented on `ModelManageableStub`:

- `model_mmap_residency` — `comfy/model_management.py:828`, `:936`
- `pinned_memory_size` — `comfy/model_management.py:938`
- `partially_unload_ram` — `comfy/model_management.py:822`

`ModelPatcher` provides all three (`model_patcher.py:370`, `:1224`, `:1228`), so most managed models are fine. But classes extending `ModelManageableStub` directly inherit the gap — `LatentUpscaleModelManageable` (`comfy_extras/nodes/nodes_latent_upscaler.py:15`) is the in-tree example, and any third-party manager built against the documented Protocol would hit the same wall. The three methods are one contract gap surfacing in three places: closing the first AttributeError unmasks the next two on the same code path, two and ten lines later.

## Reproduction

```python
import torch
import comfy.model_management as mm
from comfy_extras.nodes.nodes_latent_upscaler import LatentUpscaleModelManageable

m = LatentUpscaleModelManageable(torch.nn.Linear(64, 64).cuda(), "fake.safetensors")
mm.load_models_gpu([m])
# AttributeError: 'LatentUpscaleModelManageable' object has no attribute 'model_mmap_residency'
```

The `torch.nn.Linear` stand-in is incidental — the bug is in the manager wrapper, not the model. Real `HunyuanVideo15SRModel` / `LatentUpsampler` instances hit the same crash.

## Fix

Declare the three methods on the `ModelManageable` Protocol so the documented contract matches what the runtime requires; future implementors get static-analysis errors on omission instead of runtime AttributeErrors. Provide `@override` defaults on `ModelManageableStub` matching `ModelPatcher`'s behavior for non-mmap, non-pinned, non-dynamic models: `module_mmap_residency` delegation for `model_mmap_residency` (returns `(0, model_size)` for plain `torch.load`-style modules, since none of their tensor storages carry the `_comfy_tensor_mmap_touched` flag), `0` for `pinned_memory_size`, and a no-op `partially_unload_ram`. The lazy `from .model_management import module_mmap_residency` inside the method dodges the same circular dep that `ModelManageableStub.model_size` already handles with an in-method import.

## Validation

Four unit tests in `tests/unit/comfy_test/model_management_types_test.py` cover Protocol coverage of the 14 methods `load_models_gpu` calls, Stub coverage of the same set, an end-to-end replay of the hot-path call sequence on a stub-derived class, and the `(0, model_size)` semantic for non-mmap modules. All four pass; reverting the fix makes them fail with the production `AttributeError`, with the next failure landing on `pinned_memory_size` exactly as the runtime's unmasking sequence would. Adjacent tests under `tests/unit/comfy_test/` and `tests/unit/comfy_extras_test/` continue to pass (36 passed, 4 skipped).

Verified end-to-end on RTX 4090: pip-installed this branch on a fresh pod and ran the reproduction snippet against a real `LatentUpscaleModelManageable` — `load_models_gpu` runs to completion. Same snippet against vanilla `c5ed9402` raises the original AttributeError.

## Notes

Kept the change minimal so the contract fix isn't bundled with behavior changes — happy to expand scope if you'd rather. One follow-up worth flagging: `module_mmap_residency` walks `state_dict()` per call. For non-mmap-loaded modules that iteration is purely to confirm none of the storages carry the flag — tracking "any storage was ever flagged" at load time would let the default return `(0, model_size())` immediately. Out of scope here.